### PR TITLE
Bump appimage-builder Docker container to 0.9.1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
     default: '--skip-test'
 runs:
   using: 'docker'
-  image: docker://appimagecrafters/appimage-builder:0.8.2
+  image: docker://appimagecrafters/appimage-builder:0.9.1
   args:
     - appimage-builder
     - '--recipe=${{ inputs.recipe }}' 


### PR DESCRIPTION
The action still uses a Docker container with appimage-builder v0.8.2, which is now a pretty old version of appimage-builder. In fact, this version is so old that it did not set the GStreamer plugin path properly for my GStreamer application, which made the AppImages generated in CI runs crash at runtime (AppImages that I generated on my computer with appimage-builder v0.9.2 and v0.9.1 worked fine, though). Therefore, update the action to use the latest available appimage-builder Docker container, for v0.9.1.

v0.9.1 is not the latest version either, and I see that there is some work going on for the v1 release (great!), but I think it's nice to update this action anyway.