### PR TITLE
Fix spelling of default argument

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
   args:
     description: 'appimage-builder arguments'
     required: false
-    default: '--skip-test'
+    default: '--skip-tests'
 runs:
   using: 'docker'
   image: docker://appimagecrafters/appimage-builder:1.1.0


### PR DESCRIPTION
[action.yml](https://github.com/AppImageCrafters/build-appimage/blob/57c3bc6963f870ce3be103117de5b5e33ffbaeb6/action.yml#L14) declares `--skip-test` as default. [appimagebuilder](https://github.com/AppImageCrafters/appimage-builder/blob/42d32f11496de43a9f6a9ada7882a11296e357ca/appimagebuilder/cli/argparse.py#L66C21-L66C26) expects `--skip-tests`.

It seems that `appimagebuilder` is clever and tolerates this (treating the argument as prefix),