### PR TITLE
Allow multiple arguments

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,11 +11,10 @@ inputs:
   args:
     description: 'appimage-builder arguments'
     required: false
-    default: '--skip-test'
+    default: '--skip-tests'
 runs:
-  using: 'docker'
-  image: docker://appimagecrafters/appimage-builder:1.1.0
-  args:
-    - appimage-builder
-    - '--recipe=${{ inputs.recipe }}' 
-    - '${{ inputs.args }}'
+  using: composite
+  steps:
+    - uses: docker://appimagecrafters/appimage-builder:1.1.0
+      with:
+        args: appimage-builder --recipe=${{inputs.recipe}} ${{inputs.args}}


### PR DESCRIPTION
This PR allows to call the appimage-builder action with multiple arguments.

When an action is defined with `using: docker`, [`args` must be an array](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsargs). This means we have to create a JSON list from `appimage-builder`, `--recipe=${{inputs.recipe}}` and `inputs.args`. As far as I know, this is not possible within a single docker action because it cannot be done with [expressions](https://docs.github.com/en/actions/learn-github-actions/expressions) only.

When an action is defined with `using: composite`, [`args` is a single string](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepswithargs). That means we can simply concat `appimage-builder`, `--recipe=${{inputs.recipe}}` and `inputs.args`.

Fixes #7